### PR TITLE
发布配置函数添加'content'参数的URL编码，删除配置函数为'group'参数添加默认值

### DIFF
--- a/src/api/NacosConfigManager.lua
+++ b/src/api/NacosConfigManager.lua
@@ -5,6 +5,7 @@
 ---
 
 local httpUtils = require("utils.HttpUtils")
+local url = require("socket.url")
 
 NacosConfigManager = {}
 -- nacos open api
@@ -63,7 +64,7 @@ function NacosConfigManager.pushConfig(nacosDomain, tenant, dataId, group, conte
     end
 
     url = nacosDomain .. configUrl .. "?" .. "dataId=" .. dataId .. "&group=" .. group .. "&tenant="
-            .. tenant .. "&content=" .. content .. "&type=" .. type
+            .. tenant .. "&content=" .. url.escape(content) .. "&type=" .. type
 
     print("request url = " .. url)
 
@@ -89,8 +90,8 @@ function NacosConfigManager.deleteConfig(nacosDomain, tenant, dataId, group)
 
     end
 
-    if group == nil then
-        error("group not null")
+    if group == nil or group == "" then
+        group = "DEFAULT_GROUP"
     end
     if tenant == nil then
         tenant = ''


### PR DESCRIPTION
- 调用新增配置函数时，content 为中文 会报错。添加URL编码解决。
- 发布配置函数和获取配置函数的group参数都有默认值，删除函数应该和他们保持一致的使用方式，不赋值时，自动设置为'DEFAULT_GROUP'。